### PR TITLE
chore: added cleandb-api.platform.moleculemaker.org as an alias

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -13,6 +13,9 @@ spec:
   tls:
   - hosts:
     - {{ .Values.ingress.hostname }}
+{{- range $key, $value := .Values.ingress.extraHosts }}
+    - {{ . }}
+{{- end }}
     secretName: {{ .Values.ingress.hostname }}-tls
 {{- end }}
 {{- if .Values.ingress.className }}
@@ -29,4 +32,17 @@ spec:
               number: {{ .Values.service.port }}
         path: /
         pathType: ImplementationSpecific
+{{- range $key, $value := .Values.ingress.extraHosts }}
+  - host: {{ . }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ $.Release.Name }}
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific
+{{- end }}
+
 {{- end }}

--- a/chart/values.mmli2.yaml
+++ b/chart/values.mmli2.yaml
@@ -44,6 +44,7 @@ service:
 ingress:
   enabled: true
   hostname: "fastapi.cleandb.mmli2.ncsa.illinois.edu"
+  extraHosts: "cleandb-api.platform.moleculemaker.org"
   tls: true
   className: traefik
   annotations:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -43,7 +43,8 @@ service:
 # Define whether / how to access this application over the public internet
 ingress:
   enabled: true
-  hostname: "fastapi.cleandb.mmli1.ncsa.illinois.edu"
+  hostname: "fastapi.cleandb.mmli2.ncsa.illinois.edu"
+  extraHosts: []
   tls: true
   className: traefik
   annotations:


### PR DESCRIPTION
## Problem
We are about to publish a manuscript for CLEANDB, but the API URL is still not very user friendly

Add a slightly more user-friendly API URL alias here

Related to https://github.com/moleculemaker/CLEANDB-frontend/pull/51

## Approach
* feat: add support for ingress.extraHosts
* feat: added cleandb-api.platform.moleculemaker.org as an alias

## How to Test
1. Navigate to https://cleandb-api.platform.moleculemaker.org/api/v1/docs
    * You should see the API docs are served here